### PR TITLE
request not existing certs

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -93,8 +93,9 @@ le_check() {
 
 
     else
-    	echo "[INFO] certificate file not found for domain $DARRAYS. Starting webroot script..."
-        le_hook
+      echo "[INFO] certificate file not found for domain $DARRAYS. Starting webroot initial certificate request script..."
+      le_renew
+      echo "Certificate request process finished for domain $DARRAYS"
     fi
 
     if [ "$1" != "once" ]; then


### PR DESCRIPTION
I think a desired behavior is to request the certs also if they are not existing. That helps to setup a system with less manual initialization. Feel free to accept the pull request, if you agree to the desired behavior.
