### PR TITLE
Adds self signed certificate generation and staging environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ letsencrypt:
     - WEBROOT_PATH=/tmp/letsencrypt
     - EXP_LIMIT=30
     - CHECK_FREQ=30
+    - CHICKENEGG=
+    - STAGING=
 ```
 
 ## Once run
@@ -111,3 +113,5 @@ With this option a container will exited right after certificates update.
 * **CHMOD** Permissions for certs. Defaults to `644`.
 * **EXP_LIMIT** The number of days before expiration of the certificate before request another one. Defaults to `30`.
 * **CHECK_FREQ**: The number of days how often to perform checks. Defaults to `30`.
+* **CHICKENEGG**: Set this to 1 to generate a self signed certificate before attempting to start the process with no previous certificate. Some http servers (nginx) might not start up without a certificate file present.
+* **STAGING**: Set this to 1 to use the staging environment of letsencrypt to prevent rate limiting while working on your setup.


### PR DESCRIPTION
As mentioned in Issue #6, I ran across the same problem and decided to give it a go. This should fix the problem of nginx not starting with ssl configured on the first run.

I also added the --staging flag of certbot to an environment variable so that you can work on the setup without worrying about rate limits.

Finally, I updated the README.md accordingly.

Let me know what you think, I'm quite new to all of this.